### PR TITLE
Fixes concurrency tests.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,7 @@
         "league/flysystem-sftp-v3": "^3.0",
         "mockery/mockery": "^1.6",
         "nyholm/psr7": "^1.2",
-        "orchestra/testbench-core": "^9.3.0",
+        "orchestra/testbench-core": "^9.4.0",
         "pda/pheanstalk": "^5.0",
         "phpstan/phpstan": "^1.11.5",
         "phpunit/phpunit": "^10.5|^11.0",
@@ -197,6 +197,6 @@
             "composer/package-versions-deprecated": true
         }
     },
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -197,6 +197,6 @@
             "composer/package-versions-deprecated": true
         }
     },
-    "minimum-stability": "dev",
+    "minimum-stability": "stable",
     "prefer-stable": true
 }

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -2,19 +2,33 @@
 
 namespace Illuminate\Tests\Integration\Console;
 
-use Illuminate\Support\Facades\Concurrency;
 use Orchestra\Testbench\TestCase;
 
 class ConcurrencyTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        $this->defineCacheRoutes(<<<PHP
+<?php
+use Illuminate\Support\Facades\Concurrency;
+
+Route::any('/concurrency', function () {
+    return Concurrency::run([
+        fn () => 1 + 1,
+        fn () => 2 + 2,
+    ]);
+});
+PHP);
+
+        parent::setUp();
+    }
+
     public function testWorkCanBeDistributed()
     {
-        $this->markTestSkipped('Todo...');
+        $response = $this->get('concurrency')
+            ->assertOk();
 
-        [$first, $second] = Concurrency::run([
-            fn () => 1 + 1,
-            fn () => 2 + 2,
-        ]);
+        [$first, $second] = $response->original;
 
         $this->assertEquals(2, $first);
         $this->assertEquals(4, $second);

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -14,6 +14,7 @@ class ConcurrencyTest extends TestCase
 <?php
 
 use Illuminate\Support\Facades\Concurrency;
+use Illuminate\Support\Facades\Route;
 
 Route::any('/concurrency', function () {
     return Concurrency::run([

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -10,6 +10,7 @@ class ConcurrencyTest extends TestCase
     {
         $this->defineCacheRoutes(<<<PHP
 <?php
+
 use Illuminate\Support\Facades\Concurrency;
 
 Route::any('/concurrency', function () {

--- a/tests/Integration/Concurrency/ConcurrencyTest.php
+++ b/tests/Integration/Concurrency/ConcurrencyTest.php
@@ -3,7 +3,9 @@
 namespace Illuminate\Tests\Integration\Console;
 
 use Orchestra\Testbench\TestCase;
+use PHPUnit\Framework\Attributes\RequiresOperatingSystem;
 
+#[RequiresOperatingSystem('Linux|DAR')]
 class ConcurrencyTest extends TestCase
 {
     protected function setUp(): void


### PR DESCRIPTION
* Use Testbench Core 9.4 (not released yet)
* Publish the action to cached routes (within skeleton) so concurrency run within the skeleton scope.